### PR TITLE
Add feature: Show an alert when the bot is mentioned 

### DIFF
--- a/MMM-DiscordWatch.js
+++ b/MMM-DiscordWatch.js
@@ -12,6 +12,7 @@ Module.register("MMM-DiscordWatch", {
         fadePoint: 0.25,
         showChannel: true,
         subscribedChannels: [],
+        alertOnMentionTime: 0,
     },
 
     // Define required scripts.
@@ -38,6 +39,16 @@ Module.register("MMM-DiscordWatch", {
             else {
                 this.messages.pop();
                 this.messages.unshift(payload);
+					  if(payload.mention && this.config.alertOnMentionTime > 0){
+						  this.sendNotification("SHOW_ALERT", {
+								title: "Discord message from " + payload.author,
+								titleType: "text",
+								message: "<span class=\"large\">" + payload.text.replace(/<[^>]+>/g, '') + "</span>",
+								messageType: "html",
+								imageFA: "comment",
+								timer: this.config.alertOnMentionTime,
+							});
+					   }
             }
             this.loaded = true;
         } else if (notification === "ERROR") {
@@ -71,7 +82,7 @@ Module.register("MMM-DiscordWatch", {
 
         for (let mi in messages) {
             let message = messages[mi];
-            console.log(message);
+            //console.log(message);
 
             let mesWrapper = document.createElement("tr");
             mesWrapper.className = "normal";

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Example config:
         fadePoint: 0.25,
         showChannel: true,
         subscribedChannels: ["123456891373953034","123456038079119360"], //2 channels to listen to for example
+        alertOnMentionTime: 5000
       }
     },
 ```
@@ -61,3 +62,4 @@ Example config:
 | `fadePoint` | Location of the fade. | **0.25** |
 | `showChannel` | Whether to show the source channel of the message or not. | **true** |
 | `subscribedChannels` | Array of channels that the module will listen to | **[]** |
+| `alertOnMentionTime` | If the bot's name is mentioned in any of the subscribed channels, an alert with the message text will be displayed for this many milliseconds. | **0** |

--- a/node_helper.js
+++ b/node_helper.js
@@ -39,8 +39,9 @@ module.exports = NodeHelper.create({
 
         client.on('messageCreate', msg => {
             if (config.subscribedChannels.indexOf(msg.channel.id) > -1) {
-                self.sendSocketNotification("NEW_MESSAGE", { id: identifier, text: msg.content, author: msg.author.username, channel: msg.channel.name, createdAt: msg.createdAt })
-            }
+				mentionflag = msg.content.includes(client.user.username) || msg.content.includes(client.user.id)
+                self.sendSocketNotification("NEW_MESSAGE", { id: identifier, text: msg.content, author: msg.author.username, channel: msg.channel.name, createdAt: msg.createdAt, mention: mentionflag })
+			   }
         });
 
         client.login(config.discordToken).catch(err => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mmm-discordwatch",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mmm-discordwatch",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "CC Zero",
       "dependencies": {
         "discord.js": "^13.6.0"


### PR DESCRIPTION
Shows an alert whenever the bot’s name is mentioned in any of the monitored channels. The duration of the alert is set with the ‘alertOnMentionTime’ configuration parameter.